### PR TITLE
Faker & chromedriver troubleshooting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV FIREFOX_VERSION 58.0*
 ENV GECKO_DRIVER_VERSION v0.19.1
 ENV ROBOT_FRAMEWORK_VERSION 3.0.2
 ENV SELENIUM_LIBRARY_VERSION 3.0.1
+ENV FAKER_VERSION 4.2.0
 
 # Install system dependencies
 RUN dnf upgrade -y \
@@ -35,7 +36,8 @@ RUN dnf upgrade -y \
 # Install Robot Framework and Selenium Library
 RUN pip install \
   robotframework==$ROBOT_FRAMEWORK_VERSION \
-  robotframework-seleniumlibrary==$SELENIUM_LIBRARY_VERSION
+  robotframework-seleniumlibrary==$SELENIUM_LIBRARY_VERSION \
+  robotframework-faker==$FAKER_VERSION
 
 # Download Gecko drivers directly from the GitHub repository
 RUN wget -q "https://github.com/mozilla/geckodriver/releases/download/$GECKO_DRIVER_VERSION/geckodriver-$GECKO_DRIVER_VERSION-linux64.tar.gz" \

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Not convinced yet? Simple tests have been prepared in the `test/` folder, you ca
         -v `pwd`/test:/opt/robotframework/tests:Z \
         -e BROWSER=chrome \
         ppodgorsek/robot-framework:latest
-    
+
     # Using Firefox
     docker run \
         -v `pwd`/reports:/opt/robotframework/reports:Z \
@@ -71,7 +71,7 @@ Not convinced yet? Simple tests have been prepared in the `test/` folder, you ca
         -e BROWSER=firefox \
         ppodgorsek/robot-framework:latest
 
-For Windows users, the commands are slightly different:
+For Windows users who use **PowerShell**, the commands are slightly different:
 
     # Using Chromium
     docker run \
@@ -79,7 +79,7 @@ For Windows users, the commands are slightly different:
         -v ${PWD}/test:/opt/robotframework/tests:Z \
         -e BROWSER=chrome \
         ppodgorsek/robot-framework:latest
-    
+
     # Using Firefox
     docker run \
         -v ${PWD}/reports:/opt/robotframework/reports:Z \
@@ -88,6 +88,17 @@ For Windows users, the commands are slightly different:
         ppodgorsek/robot-framework:latest
 
 Screenshots of the results will be available in the `reports/` folder.
+
+## Troubleshooting
+Chrome drivers might crash due to the small size of `/dev/shm` in the docker container:
+> UnknownError: session deleted because of page crash
+
+To fix this issue please do one of the following:
+- Mount a volume for /dev/shm `-v /dev/shm:/dev/shm` (not working on Windows hosts)
+- Change the shm size, e.g. `shm_size: 1G`
+- Add the parameter `--tmpfs /dev/shm` to your `docker run` command to enable tmpfs
+
+More info available here: https://github.com/elgalu/docker-selenium/issues/20
 
 ## Please contribute!
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The versions used in the latest version are:
 
 * Robot Framework 3.0.2
 * Robot Framework SeleniumLibrary 3.0.1
+* Robot Framework Faker 4.2.0
 * Firefox 58.0
 * Chromium 63.0
 


### PR DESCRIPTION
- Added Faker 4.2.0 to the Robot Framework toolchain
- Added chromedriver troubleshooting for known issue

This Dockerfile has been tested on our machines and is working as expected.