### PR TITLE
Added Faker 4.2.0 to the Robot Framework toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV SCREEN_WIDTH 1920
 
 # Dependency versions
 ENV CHROMIUM_VERSION 63.0.*
+ENV FAKER_VERSION 4.2.0
 ENV FIREFOX_VERSION 58.0*
 ENV GECKO_DRIVER_VERSION v0.19.1
 ENV ROBOT_FRAMEWORK_VERSION 3.0.2
@@ -35,6 +36,7 @@ RUN dnf upgrade -y \
 # Install Robot Framework and Selenium Library
 RUN pip install \
   robotframework==$ROBOT_FRAMEWORK_VERSION \
+  robotframework-faker==$FAKER_VERSION \
   robotframework-seleniumlibrary==$SELENIUM_LIBRARY_VERSION
 
 # Download Gecko drivers directly from the GitHub repository

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ The versioning of this image follows the one of Robot Framework:
 
 The versions used in the latest version are:
 
-* Robot Framework 3.0.2
-* Robot Framework SeleniumLibrary 3.0.1
+* [Robot Framework](https://github.com/robotframework/robotframework) 3.0.2
+* [Robot Framework Faker](https://github.com/guykisel/robotframework-faker) 4.2.0
+* [Robot Framework SeleniumLibrary](https://github.com/robotframework/SeleniumLibrary) 3.0.1
 * Firefox 58.0
 * Chromium 63.0
 
@@ -63,7 +64,7 @@ Not convinced yet? Simple tests have been prepared in the `test/` folder, you ca
         -v `pwd`/test:/opt/robotframework/tests:Z \
         -e BROWSER=chrome \
         ppodgorsek/robot-framework:latest
-    
+
     # Using Firefox
     docker run \
         -v `pwd`/reports:/opt/robotframework/reports:Z \
@@ -79,7 +80,7 @@ For Windows users, the commands are slightly different:
         -v ${PWD}/test:/opt/robotframework/tests:Z \
         -e BROWSER=chrome \
         ppodgorsek/robot-framework:latest
-    
+
     # Using Firefox
     docker run \
         -v ${PWD}/reports:/opt/robotframework/reports:Z \


### PR DESCRIPTION
- Added Faker 4.2.0 to the Robot Framework toolchain

See https://github.com/ppodgorsek/docker-robot-framework/pull/69.