### PR TITLE
commenting out the VOLUME in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL description Robot Framework in Docker.
 
 # Setup volumes for input and output
 VOLUME /opt/robotframework/reports
-VOLUME /opt/robotframework/tests
+# VOLUME /opt/robotframework/tests
 
 # Setup X Window Virtual Framebuffer
 ENV SCREEN_COLOUR_DEPTH 24


### PR DESCRIPTION
VOLUME is not replaceable (See https://github.com/moby/moby/issues/3465) so adding it means that people who want to prebuild images with test data by extending your docker image are unable to do so. people can still pass in the value to the VOLUME via -v ~/tests:/opt/robotframework/tests so there is no functionality change needed for any users