### PR TITLE
futher slim down image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,9 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
     which \
     wget \
   && apk --no-cache add \
-    "firefox~$FIREFOX_VERSION" \
     "chromium~$CHROMIUM_VERSION" \
     "chromium-chromedriver~$CHROMIUM_VERSION" \
+    "firefox~$FIREFOX_VERSION" \
     xauth \
     "xvfb-run~$XVFB_VERSION" \
   && mv /usr/lib/chromium/chrome /usr/lib/chromium/chrome-original \
@@ -61,23 +61,23 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
 
 # Install Robot Framework and Selenium Library
   && pip3 install \
-  --no-cache-dir \
-  robotframework==$ROBOT_FRAMEWORK_VERSION \
-  robotframework-databaselibrary==$DATABASE_LIBRARY_VERSION \
-  robotframework-faker==$FAKER_VERSION \
-  robotframework-ftplibrary==$FTP_LIBRARY_VERSION \
-  robotframework-pabot==$PABOT_VERSION \
-  robotframework-requests==$REQUESTS_VERSION \
-  robotframework-seleniumlibrary==$SELENIUM_LIBRARY_VERSION \
-  robotframework-sshlibrary==$SSH_LIBRARY_VERSION \
-  PyYAML \
+    --no-cache-dir \
+    robotframework==$ROBOT_FRAMEWORK_VERSION \
+    robotframework-databaselibrary==$DATABASE_LIBRARY_VERSION \
+    robotframework-faker==$FAKER_VERSION \
+    robotframework-ftplibrary==$FTP_LIBRARY_VERSION \
+    robotframework-pabot==$PABOT_VERSION \
+    robotframework-requests==$REQUESTS_VERSION \
+    robotframework-seleniumlibrary==$SELENIUM_LIBRARY_VERSION \
+    robotframework-sshlibrary==$SSH_LIBRARY_VERSION \
+    PyYAML \
 
 # Download Gecko drivers directly from the GitHub repository
   && wget -q "https://github.com/mozilla/geckodriver/releases/download/$GECKO_DRIVER_VERSION/geckodriver-$GECKO_DRIVER_VERSION-linux64.tar.gz" \
-      && tar xzf geckodriver-$GECKO_DRIVER_VERSION-linux64.tar.gz \
-      && mkdir -p /opt/robotframework/drivers/ \
-      && mv geckodriver /opt/robotframework/drivers/geckodriver \
-      && rm geckodriver-$GECKO_DRIVER_VERSION-linux64.tar.gz \
+    && tar xzf geckodriver-$GECKO_DRIVER_VERSION-linux64.tar.gz \
+    && mkdir -p /opt/robotframework/drivers/ \
+    && mv geckodriver /opt/robotframework/drivers/geckodriver \
+    && rm geckodriver-$GECKO_DRIVER_VERSION-linux64.tar.gz \
   && apk del --no-cache --update-cache .build-deps
 
 # Update system path

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,36 +41,19 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
   && apk update \
   && apk --no-cache upgrade \
   && apk --no-cache --virtual .build-deps add \
-	bzip2-dev \
-	dpkg-dev dpkg \
-	expat-dev \
-	findutils \
-	gcc \
-	gdbm-dev \
-	libc-dev \
-	libffi-dev \
-	libnsl-dev \
-	libtirpc-dev \
-	linux-headers \
-	make \
+    gcc \
+    libffi-dev \
+    linux-headers \
+    make \
     musl-dev \
-	ncurses-dev \
-	openssl-dev \
-	pax-utils \
-	readline-dev \
-	tcl-dev \
-	tk \
-	tk-dev \
-	zlib-dev \
+    openssl-dev \
     which \
     wget \
   && apk --no-cache add \
-    icu-libs \
     "firefox~$FIREFOX_VERSION" \
     "chromium~$CHROMIUM_VERSION" \
     "chromium-chromedriver~$CHROMIUM_VERSION" \
     xauth \
-    coreutils \
     "xvfb-run~$XVFB_VERSION" \
   && mv /usr/lib/chromium/chrome /usr/lib/chromium/chrome-original \
   && ln -sfv /opt/robotframework/bin/chromium-browser /usr/lib/chromium/chrome \


### PR DESCRIPTION
make 2 changes to make image smaller. the first is to pull python image instead of base alpine as its smaller than us install python from apk by a bit. The second one gives decent savings by installing all install time dependencies (like dev packages) into a virtual package that we can uninstall when installing is done. this saves about 40mb