### PR TITLE
Update Dockerfile to install docutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,7 @@ RUN pip3 install \
   # Install an older Selenium version to avoid issues when running tests
   # https://github.com/robotframework/SeleniumLibrary/issues/1835
   selenium==4.9.0
+  docutils==0.21.2
 
 # Gecko drivers
 RUN dnf install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN pip3 install \
   awscli==$AWS_CLI_VERSION \
   # Install an older Selenium version to avoid issues when running tests
   # https://github.com/robotframework/SeleniumLibrary/issues/1835
-  selenium==4.9.0
+  selenium==4.9.0 \
   docutils==0.21.2
 
 # Gecko drivers


### PR DESCRIPTION
If docutils is available, user can directly use this image to run the quick start guide. https://github.com/robotframework/QuickStartGuide/blob/836eaea991140e114fba2d11c6e31f71d787070a/QuickStart.rst#installations